### PR TITLE
MINOR: get dirname of script bin/qfc.sh to allow running qfc from arb…

### DIFF
--- a/bin/qfc.sh
+++ b/bin/qfc.sh
@@ -19,6 +19,9 @@ function get_cursor_position(){
 
 if [[ -d ~/.qfc/ ]]; then
     export PATH=~/.qfc/bin:"${PATH}"
+else
+  DIRNAME=$(dirname $0)
+    export PATH=$DIRNAME:"${PATH}"
 fi
 
 if [[ -n "$ZSH_VERSION" ]]; then


### PR DESCRIPTION
…itrary location (not necessarily ~/.qfc)

This should allow the script to be sourced from arbitrary location (some users might not want to store the repository in ~/.qfc)
