### PR TITLE
Force quiet rm of tmp_file

### DIFF
--- a/bin/qfc.sh
+++ b/bin/qfc.sh
@@ -45,7 +45,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
         tmp_file=$(mktemp -t qfc.XXXXXXX)
         </dev/tty qfc --search="$word" --stdout="$tmp_file"
         result=$(<$tmp_file)
-        rm -f $tmp_file
+        /bin/rm -f -- $tmp_file
         
         # append the completion path to the user buffer
         word_length=${#word}
@@ -93,7 +93,7 @@ elif [[ -n "$BASH" ]]; then
         tmp_file=$(mktemp -t qfc.XXXXXXX)
         </dev/tty qfc --search="$word" --stdout="$tmp_file"
         result=$(<$tmp_file)
-        rm -f $tmp_file
+        /bin/rm -f -- $tmp_file
 
         word_length=${#word}
         result_length=${#result}


### PR DESCRIPTION
On my bash, and many others, rm is aliases to 'rm -vi' for safety reason, and there is no way to force rm to be quiet except to use '/bin/rm' explicitly.