### PR TITLE
allow qfc to be outside ~/.qfc

### DIFF
--- a/bin/qfc.sh
+++ b/bin/qfc.sh
@@ -17,8 +17,14 @@ function get_cursor_position(){
   echo "$row $col"
 }
 
-if [[ -d ~/.qfc/ ]]; then
-    export PATH=~/.qfc/bin:"${PATH}"
+if [[ -n  "${BASH_SOURCE[0]}" ]]; then
+    QFC_DIR="$(dirname "${BASH_SOURCE[0]}")"
+elif [[ -n $ZSH_VERSION ]]; then
+    echo QFC Dir is ${(%):-%N}
+    QFC_DIR="$(dirname "${(%):-%N}")"
+fi
+if [[ -x "$QFC_DIR/qfc" ]]; then
+    export PATH="$QFC_DIR":"${PATH}"
 fi
 
 if [[ -n "$ZSH_VERSION" ]]; then

--- a/bin/qfc.sh
+++ b/bin/qfc.sh
@@ -20,12 +20,15 @@ function get_cursor_position(){
 if [[ -n  "${BASH_SOURCE[0]}" ]]; then
     QFC_DIR="$(dirname "${BASH_SOURCE[0]}")"
 elif [[ -n $ZSH_VERSION ]]; then
-    echo QFC Dir is ${(%):-%N}
     QFC_DIR="$(dirname "${(%):-%N}")"
+else
+    QFC_DIR=~/.qfc/bin
 fi
 if [[ -x "$QFC_DIR/qfc" ]]; then
-    export PATH="$QFC_DIR":"${PATH}"
+    # export PATH="$QFC_DIR":"${PATH}"
+    alias qfc="$QFC_DIR/qfc"
 fi
+unset QFC_DIR
 
 if [[ -n "$ZSH_VERSION" ]]; then
     # zshell


### PR DESCRIPTION
I see no reason to force qfc path. This patch was tested on bash and zsh. I have also switched from updating PATH to introducing alias as there is only one script.